### PR TITLE
Avoid conflict with windows headers (abort).

### DIFF
--- a/src/compliance.h
+++ b/src/compliance.h
@@ -1,5 +1,10 @@
 
 #pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <Rcpp.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This minimal fix resolves a conflict with Windows headers (observed with LLVM/aarch64 toolchain, but could be related to newer mingw-w64, which will be soon used also on x86_64).

The problem is that the definition of macro "abort" causes compilation of headers included via windows.h to fail. This minimal fix/hack includes windows.h before the definition. It might still be worth to re-structure the code to systematically include system headers before R headers and R definitions, as recommended by Writing R Extensions.